### PR TITLE
set blas num threads to 1/2 of detected cores

### DIFF
--- a/src/run_omniscape.jl
+++ b/src/run_omniscape.jl
@@ -51,10 +51,9 @@ function run_omniscape(path::String)
     project_name = cfg["project_name"]
     r_cutoff = parse(Float64, cfg["r_cutoff"])
 
-    ## Set number of BLAS threads to 1 if running in parallel
-    if parallelize
-        BLAS.set_num_threads(1)
-    end
+    ## Set number of BLAS threads to 1/2 of number of cpu cores
+    ## currently assumes hyperthreading (hence division by two)
+    BLAS.set_num_threads(Int(length(Sys.cpu_info()) / 2))
 
     ## Store ascii header
     final_header = parse_ascii_header("$(cfg["resistance_file"])")


### PR DESCRIPTION
Related to #24

This PR sets the number of BLAS threads to 1/2 of the detected cores. If the CPU being used is hyperthreaded, then 1/2 of the detected cores (logical) will be equal to the number of physical cores, which is the ideal number of BLAS threads to use. Omniscape will use this approach for now until Julia figures out a way to default the number of BLAS threads to be to the number of physical cores instead of logical.

This method could result in slowdowns on non hyperthreaded systems, but it is still better than setting to the number of BLAS threads to 1, which is what was being done in Omniscape before (1 is still better than # of logical cores in terms of performance). 

Eventually, it may be worth adding an option for the user to specify the number of BLAS threads, but I'm not sure if the potential performance gains are worth the added complexity for the average user. More benchmarking would need to be done to get a better idea, particularly on large problems.