### PR TITLE
vl/info - suppress Circuitscape messages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,5 +13,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 StatsBase = "0.33.0"
-Circuitscape = "5.7.0"
+Circuitscape = "5.7"
 julia = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -13,4 +13,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 StatsBase = "0.33.0"
+Circuitscape = "5.7.0"
 julia = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -14,4 +14,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 StatsBase = "0.33.0"
 Circuitscape = "5.7"
-julia = "1.4"
+julia = "1.5"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | **Documentation**  | **Build Status**| **Changelog**|
 |:-----------------------------------------------------:|:------------------------------------:|:-----------:|
-| [![docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://Circuitscape.github.io/Omniscape.jl/stable) [![docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://Circuitscape.github.io/Omniscape.jl/dev) | [![Build Status](https://travis-ci.org/Circuitscape/Omniscape.jl.svg?branch=main)](https://travis-ci.org/Circuitscape/Omniscape.jl) [![Build status](https://ci.appveyor.com/api/projects/status/5mw77lobayetc9wh?svg=true)](https://ci.appveyor.com/project/vlandau/omniscape-jl) [![codecov](https://codecov.io/gh/Circuitscape/Omniscape.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/Circuitscape/Omniscape.jl) | [![news](https://img.shields.io/static/v1?label=version&message=v0.4.0-beta&color=orange)](https://github.com/Circuitscape/Omniscape.jl/blob/main/NEWS.md#news--changelog)
+| [![docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://Circuitscape.github.io/Omniscape.jl/stable) [![docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://Circuitscape.github.io/Omniscape.jl/dev) | [![Build Status](https://travis-ci.org/Circuitscape/Omniscape.jl.svg?branch=main)](https://travis-ci.org/Circuitscape/Omniscape.jl) [![Build status](https://ci.appveyor.com/api/projects/status/5mw77lobayetc9wh?svg=true)](https://ci.appveyor.com/project/vlandau/omniscape-jl) [![codecov](https://codecov.io/gh/Circuitscape/Omniscape.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/Circuitscape/Omniscape.jl) | [![news](https://img.shields.io/static/v1?label=version&message=v0.4.0&color=orange)](https://github.com/Circuitscape/Omniscape.jl/blob/main/NEWS.md#news--changelog)
 
 The Omniscape algorithm was first introduced by [McRae and colleagues](https://www.researchgate.net/publication/304842896_Conserving_Nature's_Stage_Mapping_Omnidirectional_Connectivity_for_Resilient_Terrestrial_Landscapes_in_the_Pacific_Northwest) in 2016 as a method to compute omnidirectional habitat connectivity. Omniscape.jl is an open-source, easy-to-use software package for Julia that offers an efficient and updated implementation of the Omniscape algorithm. Check out [the docs](https://circuitscape.github.io/Omniscape.jl/stable) for additional information.
 
@@ -19,7 +19,7 @@ using Pkg; Pkg.add(PackageSpec(name = "Omniscape", rev = "main"))
 
 ## Using with Docker
 
-A Docker image with the latest version of Omniscape (precompiled so `using Omniscape` will run instantly!) is [available on Docker Hub](https://hub.docker.com/r/vlandau/omniscape). To pull the image and start an Omniscape Docker container from your terminal, navigate to the directory containing your Omniscape input files (via `cd`) and run the following (set `JULIA_NUM_THREADS` to however many threads you want to use for parallel processing):
+A Docker image with the latest version of Omniscape (precompiled so `using Omniscape` will run instantly!) is [available on Docker Hub](https://hub.docker.com/r/vlandau/omniscape). To pull the image and start an Omniscape Docker container from your terminal, navigate to the directory containing your Omniscape input files (via `cd`) and run the following (setting `JULIA_NUM_THREADS` to however many threads you want to use for parallel processing):
 
 On Linux/Mac:
 ```
@@ -27,7 +27,7 @@ docker run -it --rm \
 	-v $(pwd):/home/omniscape \
 	-w /home/omniscape \
 	-e JULIA_NUM_THREADS=2 \
-	vlandau/omniscape:0.3.0
+	vlandau/omniscape:0.4.0
 ```
 
 On Windows (via Windows Command Line):
@@ -36,7 +36,7 @@ docker run -it --rm^
  -v %cd%:/home/omniscape^
  -w /home/omniscape^
  -e JULIA_NUM_THREADS=2^
- vlandau/omniscape:0.3.0
+ vlandau/omniscape:0.4.0
 ```
 Note that the `-v` flag and subsequent code will mount the files in your current working directory and make them available to the Docker container (which is why you need to run the code above from the directory containing all needed input files). Once you're in Julia in the Docker container, you're ready to go! Make sure that the file paths in your .ini file are relative to the working directory from which you ran Docker.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Omniscape algorithm was first introduced by [McRae and colleagues](https://w
 
 ## Installation
 
-Omniscape.jl currently requires Julia version 1.4 or greater. You can install Julia [here](https://julialang.org/downloads/). Once installation is complete, open a Julia terminal and run the following code to install Omniscape.jl.
+Omniscape.jl currently requires Julia version 1.5 or greater. You can install Julia [here](https://julialang.org/downloads/). Once installation is complete, open a Julia terminal and run the following code to install Omniscape.jl.
 ```julia
 using Pkg; Pkg.add("Omniscape")
 ```
@@ -51,7 +51,7 @@ Here's a bibtex entry:
     title = {{Omniscape.jl: An efficient and scalable implementation of the Omniscape algorithm in the Julia scientific computing language}},
     author = {Vincent A. Landau},
     year = {2020},
-    version = {v0.3.0},
+    version = {v0.3.1},
     url = {https://github.com/Circuitscape/Omniscape.jl},
     doi = {10.5281/zenodo.3406711}
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update && \
       build-essential
 
 # Install julia
-RUN curl -L https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz > /tmp/julia.tar.gz
+RUN curl -L https://julialang-s3.julialang.org/bin/linux/x64/1.5/julia-1.5.0-linux-x86_64.tar.gz > /tmp/julia.tar.gz
 RUN tar -zxvf /tmp/julia.tar.gz
-RUN ln -s /julia-1.4.2/bin/julia /usr/bin/julia
+RUN ln -s /julia-1.5.0/bin/julia /usr/bin/julia
 
 # Install Omniscape
 RUN julia -e 'using Pkg; Pkg.add(["Omniscape", "Test", "BenchmarkTools", "PackageCompiler"])'

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,9 +1,9 @@
 function init_cfg()
     cfg = Dict{String, String}()
 
-    cfg["resistance_file"] = "(browse to resistance file)"
+    cfg["resistance_file"] = "(path for resistance file)"
     cfg["resistance_file_is_conductance"] = "false"
-    cfg["source_file"] = "(browse to source file)"
+    cfg["source_file"] = "(path for source file)"
     cfg["project_name"] = "(filename prefix for project)"
 
     cfg["parallelize"] = "true"
@@ -26,13 +26,15 @@ function init_cfg()
     cfg["write_as_tif"] = "true"
     cfg["mask_nodata"] = "true"
 
+    cfg["suppress_cs_messages"] = "true"
+
     cfg["conditional"] = "false"
     cfg["n_conditions"] = "1"
     cfg["compare_to_future"] = "none"
-    cfg["condition1_file"] = "(browse to condition 1 file)"
-    cfg["condition2_file"] = "(browse to condition 2 file)"
-    cfg["condition1_future_file"] = "(browse to future condition 1 file)"
-    cfg["condition2_future_file"] = "(browse to future condition 2 file)"
+    cfg["condition1_file"] = "(path for condition 1 file)"
+    cfg["condition2_file"] = "(path for condition 2 file)"
+    cfg["condition1_future_file"] = "(path for future condition 1 file)"
+    cfg["condition2_future_file"] = "(path for future condition 2 file)"
     cfg["comparison1"] = "within"
     cfg["comparison2"] = "within"
     cfg["condition1_lower"] = "0"
@@ -41,7 +43,7 @@ function init_cfg()
     cfg["condition2_upper"] = "0"
 
     cfg["reclassify_resistance"] = "false"
-    cfg["reclass_table"] = "(browse to resistance reclass table file)"
+    cfg["reclass_table"] = "(path for resistance reclass table file)"
     cfg["write_reclassified_resistance"] = "false"
 
     cfg["allow_different_projections"] = "false"
@@ -81,6 +83,8 @@ function init_csdict(cfg)
     a["write_cum_cur_map_only"] =  "False"
 
     a["scenario"] = "Advanced"
+
+    a["suppress_messages"] = cfg["suppress_cs_messages"]
 
     a
 end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -519,7 +519,6 @@ function solve_target!(
 
     ## If normalize = True, calculate null map and normalize
     if calc_flow_potential == true
-        @info "Calculating flow potential for target $(i) of $(n_targets)"
         null_conductance = fill(convert(precision, 1.), grid_size)
 
         flow_potential = calculate_current(null_conductance,
@@ -583,7 +582,7 @@ function solve_target!(
             fp_cum_currmap[ylower:yupper, xlower:xupper, threadid()] .+ flow_potential
     end
 
-    @info "Target $(i) complete in $(round(time() - solve_start_time; digits = 4)) seconds"
+    @info "Time taken to solve target $(i): $(round(time() - solve_start_time; digits = 4)) seconds"
 end
 
 function calc_correction(

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -459,6 +459,8 @@ function solve_target!(
     )
 
     ## get source
+    solve_start_time = time()
+
     @info "Solving target $(i) of $(n_targets)"
     x_coord = Int64(targets[i, 1])
     y_coord = Int64(targets[i, 2])
@@ -580,6 +582,8 @@ function solve_target!(
         fp_cum_currmap[ylower:yupper, xlower:xupper, threadid()] .=
             fp_cum_currmap[ylower:yupper, xlower:xupper, threadid()] .+ flow_potential
     end
+
+    @info "Target $(i) complete in $(round(time() - solve_start_time; digits = 4)) seconds"
 end
 
 function calc_correction(

--- a/src/run_omniscape.jl
+++ b/src/run_omniscape.jl
@@ -420,7 +420,7 @@ function run_omniscape(path::String)
                      file_format)
     end
 
-    println("Done")
+    println("Done!")
     println("Time taken to complete job: $(round(time() - start_time; digits = 4)) seconds")
 
     println("Outputs written to $(string(pwd(),"/",project_name))")

--- a/src/run_omniscape.jl
+++ b/src/run_omniscape.jl
@@ -212,7 +212,7 @@ function run_omniscape(path::String)
     precision_name = precision == Float64 ? "double" : "single"
     ## Add parallel workers
     if parallelize
-        println("Starting up Omniscape. Using $(n_threads) workers in parallel. Using $(precision) precision...")
+        println("Starting up Omniscape. Using $(n_threads) workers in parallel. Using $(precision_name) precision...")
 
         cum_currmap = fill(convert(precision, 0.),
                            int_arguments["nrows"],
@@ -229,7 +229,7 @@ function run_omniscape(path::String)
             fp_cum_currmap = Array{precision, 3}(undef, 1, 1, 1)
         end
     else
-        println("Starting up Omniscape. Running in serial using 1 worker. Using $(precision) precision")
+        println("Starting up Omniscape. Running in serial using 1 worker. Using $(precision_name) precision...")
         cum_currmap = fill(convert(precision, 0.),
                           int_arguments["nrows"],
                           int_arguments["ncols"],


### PR DESCRIPTION
Suppresses most of the Circuitscape @info calls to make terminal output less noisy, bumps Julia dep to 1.5 and Circuitscape dep to 5.7