### PR TITLE
vl/fourneighbors -- add connect_four_neighbors_only option

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -65,6 +65,8 @@ julia
 
 **`allow_different_projections`:** One of true, false. Defaults to false. If true, warnings about non-matching projections are suppressed.
 
+**`connect_four_neighbors_only`:** One of true, false. Defaults to false. Circuitscape creates a graph (network) by connecting cells to their four (Fig. 4) or eight immediate neighbors. The default is eight (four cardinal and four diagonal neighbors). Set `connect_four_neighbors_only` to true if you want to connect cells to their four cardinal neighbors only.
+
 #### Resistance reclassification
 Omniscape.jl allows you to reclassify categorical resistance surfaces internally based on a user-provided reclass table. This allows the user to avoid reclassifying rasters manually in a GIS, and can streamline your workflow.
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -65,7 +65,7 @@ julia
 
 **`allow_different_projections`:** One of true, false. Defaults to false. If true, warnings about non-matching projections are suppressed.
 
-**`connect_four_neighbors_only`:** One of true, false. Defaults to false. Circuitscape creates a graph (network) by connecting cells to their four (Fig. 4) or eight immediate neighbors. The default is eight (four cardinal and four diagonal neighbors). Set `connect_four_neighbors_only` to true if you want to connect cells to their four cardinal neighbors only.
+**`connect_four_neighbors_only`:** One of true, false. Defaults to false. Circuitscape creates a graph (network) by connecting cells to their four or eight immediate neighbors. The default is eight (four cardinal and four diagonal neighbors). Set `connect_four_neighbors_only` to true if you want to connect cells to their four cardinal neighbors only.
 
 #### Resistance reclassification
 Omniscape.jl allows you to reclassify categorical resistance surfaces internally based on a user-provided reclass table. This allows the user to avoid reclassifying rasters manually in a GIS, and can streamline your workflow.

--- a/src/config.jl
+++ b/src/config.jl
@@ -17,6 +17,8 @@ function init_cfg()
     cfg["r_cutoff"] = "Inf"
     cfg["precision"] = "double"
 
+    cfg["connect_four_neighbors_only"] = "false"
+
     cfg["calc_flow_potential"] = "false"
     cfg["calc_normalized_current"] = "false"
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -437,7 +437,7 @@ function solve_target!(
         sources_raw::Array{T, 2} where T <: Number,
         resistance_raw::Array{T, 2} where T <: Number,
         cs_cfg::Dict{String, String},
-        flags::RasterFLags,
+        flags::Circuitscape.RasterFlags,
         o::Circuitscape.OutputFlags,
         calc_flow_potential::Bool,
         correct_artifacts::Bool,
@@ -577,7 +577,7 @@ end
 function calc_correction(
         arguments::Dict{String, Int64},
         cs_cfg::Dict{String, String},
-        flags,
+        flags::Circuitscape.RasterFlags,
         o,
         conditional::Bool,
         condition1_present::Array{T, 2} where T <: Number,

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -437,6 +437,7 @@ function solve_target!(
         sources_raw::Array{T, 2} where T <: Number,
         resistance_raw::Array{T, 2} where T <: Number,
         cs_cfg::Dict{String, String},
+        flags::RasterFLags,
         o::Circuitscape.OutputFlags,
         calc_flow_potential::Bool,
         correct_artifacts::Bool,
@@ -496,18 +497,6 @@ function solve_target!(
                                  resistance_file_is_conductance)
 
     grid_size = size(source)
-    n_cells = prod(grid_size)
-
-    solver = "cg+amg"
-
-    # if n_cells <= 2000000
-    #     solver = "cholmod" # FIXME: "cholmod" not available in advanced mode
-    # end
-
-    flags = Circuitscape.RasterFlags(true, false, true,
-                                     false, false,
-                                     false, Symbol("rmvsrc"),
-                                     false, false, solver, o)
 
     ## Run circuitscape
     curr = calculate_current(conductance,
@@ -588,6 +577,7 @@ end
 function calc_correction(
         arguments::Dict{String, Int64},
         cs_cfg::Dict{String, String},
+        flags,
         o,
         conditional::Bool,
         condition1_present::Array{T, 2} where T <: Number,
@@ -606,17 +596,6 @@ function calc_correction(
     # This may not apply seamlessly in the case (if I add the option) that source strengths
     # are not adjusted by target weight, but stay the same according to their
     # original values. Something to keep in mind...
-
-    solver = "cg+amg"
-
-    # if (arguments["radius"]+1)^2 <= 2000000
-    #     solver = "cholmod" # FIXME: "cholmod" not available in advanced mode
-    # end
-
-    flags = Circuitscape.RasterFlags(true, false, true,
-                                     false, false,
-                                     false, Symbol("keepall"),
-                                     false, false, solver, o)
 
     temp_source = fill(convert(precision, 1.0),
                        arguments["radius"] * 2 + buffer * 2 + 1,

--- a/src/run_omniscape.jl
+++ b/src/run_omniscape.jl
@@ -245,10 +245,25 @@ function run_omniscape(path::String)
         end
     end
 
+    # Get raster flags
+    solver = "cg+amg"
+
+    # n_cells = int_arguments["nrows"] * int_arguments["ncols"]
+    # if n_cells <= 2000000
+    #     solver = "cholmod" # FIXME: "cholmod" not available in advanced mode
+    # end
+
+    flags = Circuitscape.RasterFlags(true, false, true,
+                                     false, false,
+                                     false, Symbol("rmvsrc"),
+                                     cfg["connect_four_neighbors_only"] in TRUELIST,
+                                     false, solver, o)
+
     if correct_artifacts
         println("Calculating block artifact correction array...")
         correction_array = calc_correction(int_arguments,
                                            cs_cfg,
+                                           flags,
                                            o,
                                            conditional,
                                            condition1,
@@ -269,6 +284,7 @@ function run_omniscape(path::String)
 
     ## Calculate and accumulate currents on each worker
     println("Solving targets")
+
     if parallelize
         parallel_batch_size = Int64(round(parse(Float64, cfg["parallel_batch_size"])))
         n_batches = Int(ceil(n_targets / parallel_batch_size))
@@ -285,6 +301,7 @@ function run_omniscape(path::String)
                               sources_raw,
                               resistance_raw,
                               cs_cfg,
+                              flags,
                               o,
                               calc_flow_potential || calc_normalized_current,
                               correct_artifacts,
@@ -315,6 +332,7 @@ function run_omniscape(path::String)
                           sources_raw,
                           resistance_raw,
                           cs_cfg,
+                          flags,
                           o,
                           calc_flow_potential || calc_normalized_current,
                           correct_artifacts,

--- a/test/input/config4.ini
+++ b/test/input/config4.ini
@@ -11,6 +11,7 @@ project_name = test4
 correct_artifacts = true
 source_from_resistance = false
 r_cutoff = 0.0
+connect_four_neighbors_only = true
 
 [Conditional connectivity options]
 conditional = true


### PR DESCRIPTION
Allow use of the `connect_four_neighbors_only` Circuitscape option. Closes #60.

Added `connect_four_neighbors_only` .ini option for Omniscape, that is directly passed to Circuitscape, updated a test to use four neighbors only.

Added following docs entry for the new argument:

> **`connect_four_neighbors_only`:** One of true, false. Defaults to false. Circuitscape creates a graph (network) by connecting cells to their four or eight immediate neighbors. The default is eight (four cardinal and four diagonal neighbors). Set `connect_four_neighbors_only` to true if you want to connect cells to their four cardinal neighbors only.
