### PR TITLE
drop 0.6 from ArchGDAL compat entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
           - '1.6' 
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,8 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ArchGDAL = "0.4, 0.5, 0.6"
+ArchGDAL = "0.4, 0.5"
 Circuitscape = "5.8.1"
 ProgressMeter = "1.3"
-StatsBase = "0.33.0"
+StatsBase = "0.33"
 julia = "^1.5.4"


### PR DESCRIPTION
There was a breaking change in ArchGDAL 0.6, something about `nothing` values for NoData in some cases. Dropping this compat and sticking with v0.4/v0.5 for now until I have time to update for ArchGDAL v0.6. Going to issue a patch release.