### PR TITLE
try/catch errors to help with debugging, rework/clean internals

### DIFF
--- a/src/structs.jl
+++ b/src/structs.jl
@@ -14,3 +14,26 @@ struct OmniscapeFlags
     reclassify::Bool
     write_reclassified_resistance::Bool
 end
+
+struct Target
+    x_coord::Int64
+    y_coord::Int64
+    amps::Float64
+end
+
+struct Conditions
+    comparison1::String
+    comparison2::String
+    condition1_lower::Number
+    condition1_upper::Number
+    condition2_lower::Number
+    condition2_upper::Number
+end
+
+struct ConditionLayers
+    condition1_present::Array{Union{Missing, Number}, 2} # where T <: Number
+    condition1_future::Array{Union{Missing, Number}, 2} # where U <: Number
+    condition2_present::Array{Union{Missing, Number}, 2} # where V <: Number
+    condition2_future::Array{Union{Missing, Number}, 2} # where W <: Number
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,18 +28,18 @@ y = 4
 con1_lower = -1.0
 con1_upper = 1.0
 source_subset = convert(Array{Union{Float64, Missing}, 2}, source_subset)
+
+condition_layers = Omniscape.ConditionLayers(
+    convert(Array{Union{Float64, Missing}, 2}, con1pres),
+    convert(Array{Union{Float64, Missing}, 2}, con1fut),
+    Array{Union{Float64, Missing}, 2}(undef, 1, 1),
+    Array{Union{Float64, Missing}, 2}(undef, 1, 1)
+)
+
 Omniscape.source_target_match!(source_subset,
                      1,
-                     convert(Array{Union{Float64, Missing}, 2}, con1pres),
-                     convert(Array{Union{Float64, Missing}, 2}, con1fut),
-                     Array{Union{Float64, Missing}, 2}(undef, 1, 1),
-                     Array{Union{Float64, Missing}, 2}(undef, 1, 1),
-                     "within",
-                     "within",
-                     con1_lower, # lower bound to be within for comparisome
-                     con1_upper,
-                     0.0,
-                     0.0,
+                     condition_layers,
+                     Omniscape.Conditions("within", "within", con1_lower, con1_upper, 0.0, 0.0),
                      y,
                      y,
                      x,


### PR DESCRIPTION
On error, Omniscape will catch it and print the row and column of the moving window's central pixel -- this will make it possible eo reproduce errors in Circuitscape without needing to rerun the entire omniscape problem. This is relevant to #102 and #99.

I also took the opportunity to rework some of the internals to clean things up by creating two new structs to store data and reduce the number of arguments being passed around.