### PR TITLE
create new DOCUMENTER_KEY to address encoding error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,4 @@ jobs:
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.SSH_KEY }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Revert back to separate DOCUMENTER_KEY for deploying docs. Old key had was not formatted the way Documenter.jl needs it to be (`ERROR: LoadError: ArgumentError: malformed base64 sequence`), so I created a new key using `DocumenterTools.genkeys()` and added a corresponding deploy key and updated the secret.