### PR TITLE
Restrict Circuitscape compat to the 5.15 series to restore CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ArchGDAL = "0.10"
-Circuitscape = "5.15"
+Circuitscape = "~5.15"
 ProgressMeter = "1.3"
 StatsBase = "0.34"
 julia = "~1.11"


### PR DESCRIPTION
## Problem

CI has failed on every run since 2026-04-09, on `main` and on unrelated Dependabot PRs. The last green run was 2026-03-30.

The cause is the Circuitscape dependency rather than anything in this package. The compat entry `Circuitscape = "5.15"` permits any 5.x release, so CI installs whichever is newest when it runs. Circuitscape 5.16.0 was released 2026-04-04, and 5.17.0 and 5.17.1 on 2026-04-09 — the day CI first went red.

Tested on Julia 1.11.7 against an unmodified checkout of `main`:

| Circuitscape | `Internals` | `run_omniscape()` |
| --- | --- | --- |
| 5.17.1 | 10 / 10 passed | 6 passed, 2 failed, 1 errored |
| 5.15.0 | 10 / 10 passed | 31 / 31 passed |

The three failures on 5.17.1:

1. `test/runtests.jl:102` — flow potential from `config4a.ini` no longer matches the stored reference raster.
2. `test/runtests.jl:103` — normalized current from the same run.
3. `config_32bit.ini` stops with `CHOLMOD solver residual 0.00011793117 exceeds tolerance 1e-4 for column 1`. This ends the test set early, which is why only 9 of its 31 checks run.

The first two are consistent with Circuitscape having replaced its iterative solver between these versions; the stored reference rasters predate that change. The third appears to be a separate problem in Circuitscape — the residual check uses a fixed threshold regardless of numeric precision, and single precision leaves very little margin. I am happy to raise that with Circuitscape separately.

## This change

One line, restricting the entry to the 5.15 series:

```diff
-Circuitscape = "5.15"
+Circuitscape = "~5.15"
```

This matches the form already used for `julia` in the same file.

Verified on Julia 1.11.7: with this change, `Pkg.instantiate()` installs Circuitscape 5.15.0 and the full suite passes.

## Scope

This restores a working baseline. It does not fix the underlying incompatibility, and whether to regenerate the reference rasters and move to Circuitscape 5.17 is a larger decision that should be yours.

I was not able to test the `Documentation` job locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
