### PR TITLE
Avoid array copies in the calc_correction accumulation loop

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -488,8 +488,8 @@ function calc_correction(
 
     for i in 1:arguments["block_size"]
         for j in 1:arguments["block_size"]
-            null_current_total[i:(i + arguments["radius"] * 2 + arguments["buffer"] * 2),
-                               j:(j + arguments["radius"] * 2 + arguments["buffer"] * 2)] += null_current
+            @views null_current_total[i:(i + arguments["radius"] * 2 + arguments["buffer"] * 2),
+                                      j:(j + arguments["radius"] * 2 + arguments["buffer"] * 2)] .+= null_current
         end
     end
 


### PR DESCRIPTION
## Problem

`calc_correction` builds `null_current_total` by adding the same array into overlapping regions, once for each cell of the block:

```julia
for i in 1:arguments["block_size"]
    for j in 1:arguments["block_size"]
        null_current_total[i:(...), j:(...)] += null_current
    end
end
```

Indexing with ranges on the left of `+=` does not write in place. Each iteration copies the target region out, allocates the sum, and writes it back — two arrays of `(2*radius + 1)²` elements per iteration, `block_size²` times.

This runs before the moving window loop begins, on a single thread, so adding threads does not help.

## Change

```diff
-            null_current_total[i:(i + arguments["radius"] * 2 + arguments["buffer"] * 2),
-                               j:(j + arguments["radius"] * 2 + arguments["buffer"] * 2)] += null_current
+            @views null_current_total[i:(i + arguments["radius"] * 2 + arguments["buffer"] * 2),
+                                      j:(j + arguments["radius"] * 2 + arguments["buffer"] * 2)] .+= null_current
```

The same additions happen in the same order; only the temporaries go. `null_current_total` and `null_current` are separate arrays, so there is no aliasing to worry about.

## Results

Measured with the loop lifted out on its own, on Julia 1.11.7, `buffer = 0`. `identical` compares the raw bit patterns of the two result arrays, not `≈`.

| radius | block_size | identical | before | after | allocated before | after |
| ---: | ---: | :---: | ---: | ---: | ---: | ---: |
| 50 | 11 | yes | 0.004 s | 0.0004 s | 19 MiB | 0.09 MiB |
| 150 | 15 | yes | 0.048 s | 0.006 s | 312 MiB | 0.76 MiB |
| 300 | 31 | yes | 1.95 s | 0.100 s | 5,300 MiB | 3.04 MiB |
| 503 | 51 | yes | 10.9 s | 1.36 s | 39.3 GiB | 8.52 MiB |

The allocation figures are exact and repeatable. The times were taken on a shared machine that was busy at the time, so read them as roughly an order of magnitude rather than as precise ratios.

At the sizes used in the test suite (`radius = 5`) the difference is not measurable either way.

Test suite on Julia 1.11.7 with Circuitscape 5.15.0: `Internals` 10/10, `run_omniscape()` 31/31.

<details>
<summary>Script that produces the table</summary>

Standalone — no Omniscape state, nothing outside the standard library.

```julia
using Printf

## as written today
function current(null_current, bs, r)
    tot = zeros(Float64, 2r + bs, 2r + bs)
    for i in 1:bs, j in 1:bs
        tot[i:(i + 2r), j:(j + 2r)] += null_current
    end
    tot
end

## proposed
function withviews(null_current, bs, r)
    tot = zeros(Float64, 2r + bs, 2r + bs)
    for i in 1:bs, j in 1:bs
        @views tot[i:(i + 2r), j:(j + 2r)] .+= null_current
    end
    tot
end

bits(a) = reinterpret(UInt64, vec(a))
best(f, args...) = minimum(@elapsed(f(args...)) for _ in 1:5)

@printf("%-8s %-11s %-10s %10s %10s %8s %12s %10s\n",
        "radius", "block_size", "identical", "current", "@views", "faster", "alloc before", "after")
for (r, bs) in ((5, 3), (50, 11), (150, 15), (300, 31), (503, 51))
    nc = rand(Float64, 2r + 1, 2r + 1)
    a, b = current(nc, bs, r), withviews(nc, bs, r)
    ta, tb = best(current, nc, bs, r), best(withviews, nc, bs, r)
    aa, ab = @allocated(current(nc, bs, r)), @allocated(withviews(nc, bs, r))
    @printf("%-8d %-11d %-10s %9.4fs %9.4fs %7.1fx %10.1f MiB %6.2f MiB\n",
            r, bs, bits(a) == bits(b), ta, tb, ta / tb, aa / 2^20, ab / 2^20)
end
```

</details>

## A larger change, if you want it

The loop computes a two-dimensional convolution of `null_current` with a `block_size × block_size` box. A box filter is separable, so two passes of a sliding-window sum give the same result in far less work — about 650 times faster than the current code at `radius = 503`, against about 8 times for the change proposed here.

I have not included it. It changes the order of summation, so results differ by around 1e-13 relative, and the stored reference rasters would need to be looked at. Happy to open it separately if that is of interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
